### PR TITLE
Add `autoConnect` to SquadsEmbeddedWalletAdapter

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+    printWidth: 120,
+    tabWidth: 4,
+    trailingComma: "all",
+};

--- a/adapter.ts
+++ b/adapter.ts
@@ -66,6 +66,10 @@ export class SquadsEmbeddedWalletAdapter extends BaseWalletAdapter {
         return this._readyState;
     }
 
+    async autoConnect(): Promise<void> {
+        return super.autoConnect();
+    }
+
     async connect(): Promise<void> {
         console.log("wallet connect called");
         try {

--- a/adapter.ts
+++ b/adapter.ts
@@ -6,14 +6,9 @@ import {
     WalletNotReadyError,
     WalletReadyState,
 } from "@solana/wallet-adapter-base";
-import {
-    Connection,
-    PublicKey,
-    Transaction,
-    TransactionSignature,
-} from "@solana/web3.js";
-import {SendTransactionOptions} from "@solana/wallet-adapter-base/src/adapter";
-import {MessageBus} from "./messageBus";
+import { Connection, PublicKey, Transaction, TransactionSignature } from "@solana/web3.js";
+import { SendTransactionOptions } from "@solana/wallet-adapter-base/src/adapter";
+import { MessageBus } from "./messageBus";
 
 export const EmbeddedWalletName = "Squads Multisig" as WalletName;
 export const ParentWindowName = "squads-custom-app";
@@ -39,7 +34,7 @@ export class SquadsEmbeddedWalletAdapter extends BaseWalletAdapter {
         this._connecting = false;
         this._publicKey = null;
         this._messageBus = null;
-        this._targetOrigin = targetOrigin
+        this._targetOrigin = targetOrigin;
 
         if (this._readyState !== WalletReadyState.Unsupported) {
             scopePollingDetectionStrategy(() => {
@@ -93,7 +88,7 @@ export class SquadsEmbeddedWalletAdapter extends BaseWalletAdapter {
             this._publicKey = new PublicKey(vaultInfo[0].pubkey);
             this.emit("connect", this._publicKey);
         } catch (error: any) {
-            console.log(error)
+            console.log(error);
             this.emit("error", error);
             throw error;
         } finally {
@@ -123,7 +118,7 @@ export class SquadsEmbeddedWalletAdapter extends BaseWalletAdapter {
                     data: instr.data.toJSON(),
                     programId: instr.programId.toString(),
                 })),
-                type: "string"
+                type: "string",
             }
         );
     }
@@ -132,52 +127,59 @@ export class SquadsEmbeddedWalletAdapter extends BaseWalletAdapter {
         if (!this.connected) throw new WalletNotConnectedError();
         if (!this._messageBus) throw new WalletNotReadyError();
 
-        const instructions: any[] = []
-        txs.forEach((tx) => tx.instructions.forEach((instr) => {
-            instructions.push({
-                keys: instr.keys.map((key) => ({
-                    pubkey: key.pubkey.toString(),
-                    isSigner: key.isSigner,
-                    isWritable: key.isWritable,
-                })),
-                data: instr.data.toJSON(),
-                programId: instr.programId.toString(),
+        const instructions: any[] = [];
+        txs.forEach((tx) =>
+            tx.instructions.forEach((instr) => {
+                instructions.push({
+                    keys: instr.keys.map((key) => ({
+                        pubkey: key.pubkey.toString(),
+                        isSigner: key.isSigner,
+                        isWritable: key.isWritable,
+                    })),
+                    data: instr.data.toJSON(),
+                    programId: instr.programId.toString(),
+                });
             })
-        }))
+        );
 
         return await this._messageBus.sendRequest(
             `proposeTransaction#${Date.now()}`,
             "proposeTransaction",
             {
                 instructions: instructions,
-                type: "array"
+                type: "array",
             }
         );
     }
 
-    async sendAll(txWithSigners: { tx: Transaction, signers?: [] | undefined }[], _opts?: any): Promise<string[]> {
+    async sendAll(
+        txWithSigners: { tx: Transaction; signers?: [] | undefined }[],
+        _opts?: any
+    ): Promise<string[]> {
         if (!this.connected) throw new WalletNotConnectedError();
         if (!this._messageBus) throw new WalletNotReadyError();
 
-        const instructions: any[] = []
-        txWithSigners.forEach((tx) => tx.tx.instructions.forEach((instr) => {
-            instructions.push({
-                keys: instr.keys.map((key) => ({
-                    pubkey: key.pubkey.toString(),
-                    isSigner: key.isSigner,
-                    isWritable: key.isWritable,
-                })),
-                data: instr.data.toJSON(),
-                programId: instr.programId.toString(),
+        const instructions: any[] = [];
+        txWithSigners.forEach((tx) =>
+            tx.tx.instructions.forEach((instr) => {
+                instructions.push({
+                    keys: instr.keys.map((key) => ({
+                        pubkey: key.pubkey.toString(),
+                        isSigner: key.isSigner,
+                        isWritable: key.isWritable,
+                    })),
+                    data: instr.data.toJSON(),
+                    programId: instr.programId.toString(),
+                });
             })
-        }))
+        );
 
         return await this._messageBus.sendRequest(
             `proposeTransaction#${Date.now()}`,
             "proposeTransaction",
             {
                 instructions: instructions,
-                type: "array"
+                type: "array",
             }
         );
     }
@@ -199,7 +201,7 @@ export class SquadsEmbeddedWalletAdapter extends BaseWalletAdapter {
                     data: instr.data.toJSON(),
                     programId: instr.programId.toString(),
                 })),
-                type: "string"
+                type: "string",
             }
         );
     }
@@ -225,7 +227,7 @@ export class SquadsEmbeddedWalletAdapter extends BaseWalletAdapter {
                     data: instr.data.toJSON(),
                     programId: instr.programId.toString(),
                 })),
-                type: "string"
+                type: "string",
             }
         );
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lib"
   ],
   "dependencies": {
-    "@solana/wallet-adapter-base": "^0.9.21",
+    "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/web3.js": "^1.73.2",
     "bs58": "^5.0.0",
     "encoding": "^0.1.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,23 +31,23 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/wallet-adapter-base@^0.9.21":
-  version "0.9.21"
-  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.21.tgz#6e73e550aa64a12174ec746bbf338c21209cf70e"
-  integrity sha512-UPC7GKAMbeoF5Ki+eTi1BHCTjbhtxGIAbgfzSkgYYQKoziDcSr5EgdBL1ntO6wwe6/fRByO6J4q/Dhr7vakz7A==
+"@solana/wallet-adapter-base@^0.9.23":
+  version "0.9.23"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.23.tgz#3b17c28afd44e173f44f658bf9700fd637e12a11"
+  integrity sha512-apqMuYwFp1jFi55NxDfvXUX2x1T0Zh07MxhZ/nCCTGys5raSfYUh82zen2BLv8BSDj/JxZ2P/s7jrQZGrX8uAw==
   dependencies:
-    "@solana/wallet-standard-features" "^1.0.0"
+    "@solana/wallet-standard-features" "^1.1.0"
     "@wallet-standard/base" "^1.0.1"
-    "@wallet-standard/features" "^1.0.1"
-    eventemitter3 "^4.0.0"
+    "@wallet-standard/features" "^1.0.3"
+    eventemitter3 "^4.0.7"
 
-"@solana/wallet-standard-features@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-features/-/wallet-standard-features-1.0.0.tgz#fee71c47fa8c4bacbdc5c8750487e60a2e5e6746"
-  integrity sha512-cZKUm2w67MQOAzbfdZCGAbePWuqSwpvpbWA2K2D0UcHX30I8ry8YEeHlqwqULIOTeY8lRCHu8WMxZwC9iMEqHQ==
+"@solana/wallet-standard-features@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-features/-/wallet-standard-features-1.1.0.tgz#516d78626dd0802d299db49298e4ebbec3433940"
+  integrity sha512-oVyygxfYkkF5INYL0GuD8GFmNO/wd45zNesIqGCFE6X66BYxmI6HmyzQJCcZTZ0BNsezlVg4t+3MCL5AhfFoGA==
   dependencies:
-    "@wallet-standard/base" "^1.0.0"
-    "@wallet-standard/features" "^1.0.0"
+    "@wallet-standard/base" "^1.0.1"
+    "@wallet-standard/features" "^1.0.3"
 
 "@solana/web3.js@^1.73.2":
   version "1.73.2"
@@ -100,12 +100,12 @@
   dependencies:
     "@types/node" "*"
 
-"@wallet-standard/base@^1.0.0", "@wallet-standard/base@^1.0.1":
+"@wallet-standard/base@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@wallet-standard/base/-/base-1.0.1.tgz#860dd94d47c9e3c5c43b79d91c6afdbd7a36264e"
   integrity sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==
 
-"@wallet-standard/features@^1.0.0", "@wallet-standard/features@^1.0.1":
+"@wallet-standard/features@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@wallet-standard/features/-/features-1.0.3.tgz#c992876c5e4f7a0672f8869c4146c87e0dfe48c8"
   integrity sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==
@@ -252,7 +252,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-eventemitter3@^4.0.0, eventemitter3@^4.0.7:
+eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==


### PR DESCRIPTION
The following:
```ts
const wallets: Adapter[] = detectEmbeddedInSquadsIframe()
  ? [new SquadsEmbeddedWalletAdapter('https://iframe-preview.squads.so')]
  : [new PhantomWalletAdapter(), new SolflareWalletAdapter()];
return (
  <WalletProvider wallets={wallets} autoConnect>
    {props.children}
  </WalletProvider>
);
```
was giving me this error:
```
Type 'SquadsEmbeddedWalletAdapter[] | (PhantomWalletAdapter | SolflareWalletAdapter)[]' is not assignable to type 'Adapter[]'.
  Type 'SquadsEmbeddedWalletAdapter[]' is not assignable to type 'Adapter[]'.
    Type 'SquadsEmbeddedWalletAdapter' is not assignable to type 'Adapter'.
      Type 'SquadsEmbeddedWalletAdapter' is not assignable to type 'SignerWalletAdapter'.
        Property 'autoConnect' is missing in type 'SquadsEmbeddedWalletAdapter' but required in type 'WalletAdapterProps<string>'.
```

Changes were tested by importing my fork:
```
{
  ...
  "dependencies": {
    ...
    "@sqds/iframe-adapter": "github:jessupjn/iframe-adapter"
  }
}
```